### PR TITLE
add_url_rules actually defaults to True, so update the documentation accordingly

### DIFF
--- a/flaskext/autoindex/__init__.py
+++ b/flaskext/autoindex/__init__.py
@@ -33,7 +33,7 @@ class AutoIndex(object):
     :param browse_root: a path which is served by root address.
     :param add_url_rules: if it is ``True``, the wrapped application routes
                           ``/`` and ``/<path:path>`` to autoindex. default
-                          is ``False``.
+                          is ``True``.
     :param **silk_options: keyword options for :class:`flaskext.silk.Silk`
     """
 


### PR DESCRIPTION
This caused us some confusion when we had autoindex under a /src/ URL, but autoindex was automatically generating URLs with / instead of /src/.
