### PR TITLE
Adding a template_context keyword to allow passing of fields to templates

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -161,6 +161,11 @@ Your templates could extend the default Flask-AutoIndex's template, it named
      </div>
    {% endblock %}
 
+To get extra fields through to your template, pass them in the
+``template_context`` keyword argument::
+
+    AutoIndex(app, template_context = dict(SITENAME = 'My cool site'))
+
 API
 ===
 

--- a/flask_autoindex/__init__.py
+++ b/flask_autoindex/__init__.py
@@ -62,7 +62,7 @@ class AutoIndex(object):
             raise TypeError("'base' should be Flask or Blueprint.")
 
     def __init__(self, base, browse_root=None, add_url_rules=True,
-                 **silk_options):
+                 template_context={}, **silk_options):
         """Initializes an autoindex instance."""
         self.base = base
         if browse_root:
@@ -73,6 +73,7 @@ class AutoIndex(object):
         self.silk = Silk(self.base, **silk_options)
         self.icon_map = []
         self.converter_map = []
+        self.template_context = template_context
         if add_url_rules:
             @self.base.route('/')
             @self.base.route('/<path:path>')
@@ -80,7 +81,7 @@ class AutoIndex(object):
                 return self.render_autoindex(path)
 
     def render_autoindex(self, path, browse_root=None, template=None,
-                         endpoint='.autoindex'):
+                         template_context = {}, endpoint='.autoindex'):
         """Renders an autoindex with the given path.
 
         :param path: the relative path
@@ -102,7 +103,9 @@ class AutoIndex(object):
             entries = curdir.explore(sort_by=sort_by, order=order)
             if callable(endpoint):
                 endpoint = endpoint.__name__
-            context = dict(curdir=curdir, entries=entries,
+            context = dict(self.template_context.items() +
+                           template_context.items(),
+                           curdir=curdir, entries=entries,
                            sort_by=sort_by, order=order, endpoint=endpoint)
             if template:
                 return render_template(template, **context)


### PR DESCRIPTION
The AutoIndex class and render_autoindex method now take an extra keyword argument `template_context` whose contents are passed to `render_template`.  This allows custom templates to get extra fields so they can inherit from and work with other templates in the application.

For example, I want my autoindex.html template to import my base.html, which includes its own breadcrumbs, menus, etc. but needs my fields.

(In case you're interested, I use `add_url_rules = False` and call `render_autoindex` explicitly.)

Thanks!
