### PR TITLE
Allow hidden files (starting with '.') to be shown in indexes.

### DIFF
--- a/flask_autoindex/__init__.py
+++ b/flask_autoindex/__init__.py
@@ -64,7 +64,8 @@ class AutoIndex(object):
             raise TypeError("'base' should be Flask or Blueprint.")
 
     def __init__(self, base, browse_root=None, add_url_rules=True,
-                 template_context=None, silk_options=None):
+                 template_context=None, silk_options=None,
+                 show_hidden=False):
         """Initializes an autoindex instance."""
         self.base = base
         if browse_root:
@@ -76,6 +77,7 @@ class AutoIndex(object):
             silk_options = {}
         silk_options['silk_path'] = silk_options.get('silk_path', '/__icons__')
         self.silk = Silk(self.base, **silk_options)
+        self.show_hidden = show_hidden
         self.icon_map = []
         self.converter_map = []
         if add_url_rules:
@@ -85,7 +87,8 @@ class AutoIndex(object):
                 return self.render_autoindex(path)
 
     def render_autoindex(self, path, browse_root=None, template=None,
-                         template_context=None, endpoint='.autoindex'):
+                         template_context=None, endpoint='.autoindex',
+                         show_hidden=None):
         """Renders an autoindex with the given path.
 
         :param path: the relative path.
@@ -95,6 +98,7 @@ class AutoIndex(object):
         :param template_context: would be passed to the Jinja2 template when
                                  rendering an AutoIndex page.
         :param endpoint: an endpoint which is a function.
+        :param show_hidden: whether to show hidden files (starting with '.')
         """
         if browse_root:
             rootdir = RootDirectory(browse_root, autoindex=self)
@@ -106,7 +110,9 @@ class AutoIndex(object):
             sort_by = request.args.get('sort_by', 'name')
             order = {'asc': 1, 'desc': -1}[request.args.get('order', 'asc')]
             curdir = Directory(path, rootdir)
-            entries = curdir.explore(sort_by=sort_by, order=order)
+            if show_hidden == None: show_hidden = self.show_hidden
+            entries = curdir.explore(sort_by=sort_by, order=order,
+                                     show_hidden=show_hidden)
             if callable(endpoint):
                 endpoint = endpoint.__name__
             context = {}


### PR DESCRIPTION
Add the keyword parameter "show_hidden" to both AutoIndex init and render_autoindex methods, with the former providing a default for the latter.  The logic was already there in the "explore" but had not been plumbed through to the external interface.
