### PR TITLE
Fixed displaying of size for empty files.

### DIFF
--- a/flask_autoindex/entry.py
+++ b/flask_autoindex/entry.py
@@ -162,6 +162,7 @@ class File(Entry):
 
     default_icon = 'page_white.png'
     icon_map = []
+    isdir=False
 
     def __new__(cls, path, rootdir=None, autoindex=None):
         try:
@@ -209,6 +210,7 @@ class Directory(Entry):
 
     default_icon = 'folder.png'
     icon_map = []
+    isdir=True
 
     def __new__(cls, *args, **kwargs):
         """If the path is same with root path, it returns a

--- a/flask_autoindex/templates/__autoindex__/macros.html
+++ b/flask_autoindex/templates/__autoindex__/macros.html
@@ -18,7 +18,7 @@
       <time datetime="{{ ent.modified }}">{{ ent.modified }}</time>
     </td>
     <td class="size">
-      {% if ent.size %}
+      {% if not ent.isdir %}
         {{ ent.size|filesizeformat }}
       {% else %}
         -


### PR DESCRIPTION
Empty files was treated as directories and a - was show instead of 0 in
the size column.
