### PR TITLE
Make title of page editable

### DIFF
--- a/flask_autoindex/templates/__autoindex__/autoindex.html
+++ b/flask_autoindex/templates/__autoindex__/autoindex.html
@@ -5,7 +5,9 @@
 <html>
 <head>
   <meta charset="utf-8" />
-  <title>Index of {{ curdir.path }}</title>
+  {% block title %}
+    <title>Index of {{ curdir.path }}</title>
+  {% endblock %}
   {% block meta %}
     <link rel="stylesheet" type="text/css"
       href="{{ url_for('__autoindex__.static', filename='autoindex.css') }}" />


### PR DESCRIPTION
This change puts the `<title>` element in it's own block so it can be changed by users.  

Something as subjective as the page title should not be hardcoded into the template IMO.

I created a new block instead of reusing the `meta` block to avoid breaking the title on templates created prior to this change.